### PR TITLE
ci: fix actions.

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -55,7 +55,7 @@ jobs:
             build/linux/${{ matrix.arch }}/${{ matrix.mode }}
 
       - name: Run tests
-        if: ${{ matrix.arch }} === "x86_64"
+        if: matrix.arch == 'x86_64'
         run: |
           xmake build googletest
           xmake run googletest

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -47,13 +47,15 @@ jobs:
           xmake f -a ${{ matrix.arch }} -m ${{ matrix.mode }} -p linux -v -y
           xmake -v -y
 
-      - name: Run tests
-        run: |
-          xmake run googletest
-
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: allay-launcher-linux-${{ matrix.arch }}-${{ matrix.mode }}
           path: |
             build/linux/${{ matrix.arch }}/${{ matrix.mode }}
+
+      - name: Run tests
+        if: ${{ matrix.arch }} === "x86_64"
+        run: |
+          xmake build googletest
+          xmake run googletest

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -1,4 +1,4 @@
-name: Build (Linux)
+name: Build & Test (Linux)
 
 on:
   push:
@@ -36,11 +36,7 @@ jobs:
             ~/.cache/zig
           key: xmake-linux-${{ matrix.arch }}-${{ hashFiles('xmake.lua') }}
           restore-keys: |
-            xmake-linux-${{ matrix.arch }}-${{ matrix.mode }}-
-
-      - name: Sync with repository
-        run: |
-          xmake repo -u
+            xmake-linux-${{ matrix.arch }}-
 
       - name: Build for host
         run: |
@@ -57,5 +53,4 @@ jobs:
       - name: Run tests
         if: matrix.arch == 'x86_64'
         run: |
-          xmake build googletest
-          xmake run googletest
+          xmake build googletest && xmake run googletest

--- a/.github/workflows/build-macosx.yml
+++ b/.github/workflows/build-macosx.yml
@@ -47,13 +47,13 @@ jobs:
           xmake f -a ${{ matrix.arch }} -m ${{ matrix.mode }} -p macosx -v -y
           xmake -v -y
 
-      - name: Run tests
-        run: |
-          xmake run googletest
-
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: allay-launcher-macosx-${{ matrix.arch }}-${{ matrix.mode }}
           path: |
             build/macosx/${{ matrix.arch }}/${{ matrix.mode }}
+  
+      - name: Run tests
+        run: |
+          xmake build googletest && xmake run googletest

--- a/.github/workflows/build-macosx.yml
+++ b/.github/workflows/build-macosx.yml
@@ -54,6 +54,6 @@ jobs:
           path: |
             build/macosx/${{ matrix.arch }}/${{ matrix.mode }}
   
-      - name: Run tests
-        run: |
-          xmake build googletest && xmake run googletest
+#      - name: Run tests
+#        run: |
+#          xmake build googletest && xmake run googletest

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -45,13 +45,13 @@ jobs:
         run: |
           xmake -v -y
 
-      - name: Run tests
-        run: |
-          xmake run googletest
-
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: allay-launcher-windows-x64-${{ matrix.mode }}
           path: |
             build/windows/x64/${{ matrix.mode }}
+
+      - name: Run tests
+        run: |
+          xmake build googletest && xmake run googletest

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -1,4 +1,4 @@
-name: Build (Windows)
+name: Build & Test (Windows)
 
 on:
   push:
@@ -32,10 +32,6 @@ jobs:
 
       - name: Setup MSVC
         uses: microsoft/setup-msbuild@v2
-
-      - name: Sync with repository
-        run: |
-          xmake repo -u
 
       - name: Configure
         run: |


### PR DESCRIPTION
The tests for MacOSX are not working for now, waiting for AllayLauncher to add `GITHUB_TOKEN` support.

Reference: https://github.com/actions/runner-images/issues/602